### PR TITLE
electron:buildで作った生成物でindex.htmlが読み込めていない

### DIFF
--- a/template/electron/main.ts
+++ b/template/electron/main.ts
@@ -1,6 +1,6 @@
 import {app, BrowserWindow, ipcMain} from 'electron';
-import * as path from 'path';
-import * as isDev from 'electron-is-dev';
+import path from 'path';
+import isDev from 'electron-is-dev';
 
 let win: BrowserWindow | null = null;
 


### PR DESCRIPTION
Fixes #1

tsconfigで"esModuleInterop": trueにしたので
import * as foo from 'foo'を
import foo from 'foo'に書き換えた